### PR TITLE
freeglut is not a dependency in macOS

### DIFF
--- a/ports/jasper/CONTROL
+++ b/ports/jasper/CONTROL
@@ -2,4 +2,4 @@ Source: jasper
 Version: 2.0.16-2
 Homepage: https://github.com/mdadams/jasper
 Description: Open source implementation of the JPEG-2000 Part-1 standard
-Build-Depends: libjpeg-turbo, opengl, freeglut
+Build-Depends: libjpeg-turbo, opengl, freeglut (!osx)


### PR DESCRIPTION
What is good because freeglut cannot be build in the latest versions of macOS

**Describe the pull request**

- What does your PR fix? Fixes issue #

- Which triplets are supported/not supported? Have you updated the CI baseline?

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
